### PR TITLE
Fix/vendor specific application

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,20 +84,27 @@ Configurations
 
 ### Diameter Config
 
-| Field Name                     | Type                          | Description                                                                  |
-| ------------------------------ | ----------------------------- | -----------------------------------------------------------------------------|
-| RequestTimeout                 | duration                      | Timeout for each request                                                     |
-| MaxRetransmits                 | number                        | Maximum number of message retransmissions                                    |
-| RetransmitInterval             | duration                      | Interval between message retransmissions                                     |
-| EnableWatchdog                 | boolean                       | Flag to enable automatic DWR (Diameter Watchdog Request)                     |
-| WatchdogInterval               | duration                      | Interval between sending DWRs                                                |
-| WatchdogStream                 | number                        | Stream ID for sending DWRs (for multistreaming protocols)                    |
-| SupportedVendorID              | number array                  | List of supported vendor IDs                                                 |
-| AcctApplicationID              | number array                  | List of accounting application IDs                                           |
-| AuthApplicationID              | number array                  | List of authentication application IDs                                       |
-| VendorSpecificApplicationID    | number array                  | List of vendor-specific application IDs                                      |
-| CapabilityExchange             | object                        | Configuration for capability exchange                                        |
-| TransportProtocol              | string                        | Transport layer protocol to use, either "tcp" or "sctp". Defaults to "tcp"   |
+| Field Name                  | Type         | Description                                                                |
+|-----------------------------|--------------|----------------------------------------------------------------------------|
+| RequestTimeout              | duration     | Timeout for each request                                                   |
+| MaxRetransmits              | number       | Maximum number of message retransmissions                                  |
+| RetransmitInterval          | duration     | Interval between message retransmissions                                   |
+| EnableWatchdog              | boolean      | Flag to enable automatic DWR (Diameter Watchdog Request)                   |
+| WatchdogInterval            | duration     | Interval between sending DWRs                                              |
+| WatchdogStream              | number       | Stream ID for sending DWRs (for multistreaming protocols)                  |
+| SupportedVendorID           | number array | List of supported vendor IDs                                               |
+| AcctApplicationID           | number array | List of accounting application IDs                                         |
+| AuthApplicationID           | number array | List of authentication application IDs                                     |
+| VendorSpecificApplicationID | object       | List of vendor-specific application IDs                                    |
+| CapabilityExchange          | object       | Configuration for capability exchange                                      |
+| TransportProtocol           | string       | Transport layer protocol to use, either "tcp" or "sctp". Defaults to "tcp" |
+
+### Vendor Specific Application Id Config
+| Field Name        | Type   | Description         |
+|-------------------|--------|---------------------|
+| VendorID          | number | Vendor ID           |
+| AuthApplicationID | number | Auth Application ID |
+| AcctApplicationID | number | Acct Application ID |
 
 ### Capability Exchange Config
 
@@ -118,6 +125,12 @@ let client = diam.Client({
     requestTimeout: "50ms",
     enableWatchdog: false,
     authApplicationId: [app.ChargingControl],
+    vendorSpecificApplicationId: [
+        {
+            authApplicationId: app.ChargingControl,
+            vendorId: vendor.TGPP,
+        }
+    ],
     capabilityExchange: {
         vendorId: 35838,
     },

--- a/config.go
+++ b/config.go
@@ -7,18 +7,24 @@ import (
 )
 
 type DiameterConfig struct {
-	RequestTimeout              *Duration                 `json:"requestTimeout,omitempty"`
-	MaxRetransmits              *uint                     `json:"maxRetransmits,omitempty"`
-	RetransmitInterval          *Duration                 `json:"retransmitInterval,omitempty"`
-	EnableWatchdog              *bool                     `json:"enableWatchdog,omitempty"`
-	WatchdogInterval            *Duration                 `json:"watchdogInterval,omitempty"`
-	WatchdogStream              *uint                     `json:"watchdogStream,omitempty"`
-	SupportedVendorID           *[]uint32                 `json:"supportedVendorID,omitempty"`
-	AcctApplicationID           *[]uint32                 `json:"acctApplicationId,omitempty"`
-	AuthApplicationId           *[]uint32                 `json:"authApplicationId,omitempty"`
-	VendorSpecificApplicationID *[]uint32                 `json:"vendorSpecificApplicationId,omitempty"`
-	TransportProtocol           *string                   `josn:"transportProtocol,omitempty"`
-	CapabilityExchange          *CapabilityExchangeConfig `json:"capabilityExchange,omitempty"`
+	RequestTimeout              *Duration                            `json:"requestTimeout,omitempty"`
+	MaxRetransmits              *uint                                `json:"maxRetransmits,omitempty"`
+	RetransmitInterval          *Duration                            `json:"retransmitInterval,omitempty"`
+	EnableWatchdog              *bool                                `json:"enableWatchdog,omitempty"`
+	WatchdogInterval            *Duration                            `json:"watchdogInterval,omitempty"`
+	WatchdogStream              *uint                                `json:"watchdogStream,omitempty"`
+	SupportedVendorID           *[]uint32                            `json:"supportedVendorID,omitempty"`
+	AcctApplicationID           *[]uint32                            `json:"acctApplicationId,omitempty"`
+	AuthApplicationId           *[]uint32                            `json:"authApplicationId,omitempty"`
+	VendorSpecificApplicationID *[]VendorSpecificApplicationIDConfig `json:"vendorSpecificApplicationId,omitempty"`
+	TransportProtocol           *string                              `josn:"transportProtocol,omitempty"`
+	CapabilityExchange          *CapabilityExchangeConfig            `json:"capabilityExchange,omitempty"`
+}
+
+type VendorSpecificApplicationIDConfig struct {
+	VendorID          *uint32 `json:"vendorId,omitempty"`
+	AuthApplicationID *uint32 `json:"authApplicationId,omitempty"`
+	AcctApplicationID *uint32 `json:"acctApplicationId,omitempty"`
 }
 
 type CapabilityExchangeConfig struct {
@@ -64,7 +70,7 @@ func setDiameterConfigDefaults(config *DiameterConfig) {
 	var defaultSupportedVendorID = []uint32{}
 	var defaultAcctApplicationID = []uint32{}
 	var defaultAuthApplicationID = []uint32{}
-	var defaultVendorSpecificApplicationID = []uint32{}
+	var defaultVendorSpecificApplicationID = []VendorSpecificApplicationIDConfig{}
 	var defaultTransportProtocol = "tcp"
 
 	// Set defaults for DiameterConfig

--- a/diameter.go
+++ b/diameter.go
@@ -79,8 +79,25 @@ func (*Diameter) XClient(arg map[string]interface{}) (*DiameterClient, error) {
 	}
 
 	VendorSpecificApplicationID := []*diam.AVP{}
-	for _, appID := range *config.VendorSpecificApplicationID {
-		VendorSpecificApplicationID = append(VendorSpecificApplicationID, diam.NewAVP(avp.VendorSpecificApplicationID, avp.Mbit, 0, datatype.Unsigned32(appID)))
+	for _, vendorSpecificApplicationId := range *config.VendorSpecificApplicationID {
+		avps := []*diam.AVP{}
+
+		if vendorSpecificApplicationId.AuthApplicationID != nil {
+			authApplicationID := vendorSpecificApplicationId.AuthApplicationID
+			avps = append(avps, diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(*authApplicationID)))
+		}
+
+		if vendorSpecificApplicationId.AcctApplicationID != nil {
+			acctApplicationID := vendorSpecificApplicationId.AcctApplicationID
+			avps = append(avps, diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(*acctApplicationID)))
+		}
+
+		if vendorSpecificApplicationId.VendorID != nil {
+			vendorID := vendorSpecificApplicationId.VendorID
+			avps = append(avps, diam.NewAVP(avp.VendorID, avp.Mbit, 0, datatype.Unsigned32(*vendorID)))
+		}
+
+		VendorSpecificApplicationID = append(VendorSpecificApplicationID, diam.NewAVP(avp.VendorSpecificApplicationID, avp.Mbit, 0, &diam.GroupedAVP{AVP: avps}))
 	}
 
 	client := &sm.Client{

--- a/example/example.js
+++ b/example/example.js
@@ -18,6 +18,12 @@ let client = diam.Client({
     requestTimeout: "50ms",
     enableWatchdog: false,
     authApplicationId: [app.ChargingControl],
+    vendorSpecificApplicationId: [
+        {
+            authApplicationId: app.ChargingControl,
+            vendorId: vendor.TGPP,
+        }
+    ],
     capabilityExchange: {
         vendorId: 35838,
     },


### PR DESCRIPTION
Hello!

While using the extension I've noticed that the format of the `Vendor-Specific-Application-Id` was not conforming to the expected grouped type described in the base protocol. This AVP is defined in [section 6.11 of the RFC 6733](https://datatracker.ietf.org/doc/html/rfc6733#section-6.11).

This PR adds the configuration option for multiple `Vendor-Specific-Application-Id` AVPs.