### PR TITLE
Feature/custom metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export default function () {
     ])))
 
     const cca = client.send(ccr)
-    console.log("CCA: ", cca)
+    console.log(`CCA: ${cca}`)
 
     const resultCode = cca.findAVP(code.ResultCode, 0)
     check(resultCode, {'Result-Code == 2001': r => r == 2001,})

--- a/diameter.go
+++ b/diameter.go
@@ -187,8 +187,8 @@ func (c *DiameterClient) Send(msg *DiameterMessage) (*DiameterMessage, error) {
 			"cmd_code": strconv.FormatUint(uint64(msg.diamMsg.Header.CommandCode), 10),
 		}
 		now := time.Now()
-		c.reportMetric(c.metrics.RequestDuration, time.Now(), metrics.D(now.Sub(sentAt)), tags)
-		c.reportMetric(c.metrics.RequestCount, time.Now(), 1, tags)
+		c.reportMetric(c.metrics.RequestDuration, now, metrics.D(now.Sub(sentAt)), tags)
+		c.reportMetric(c.metrics.RequestCount, now, 1, tags)
 
 		delete(c.hopIds, hopByHopID)
 

--- a/diameter.go
+++ b/diameter.go
@@ -190,6 +190,7 @@ func (c *DiameterClient) Send(msg *DiameterMessage) (*DiameterMessage, error) {
 		now := time.Now()
 		c.reportMetric(c.metrics.RequestDuration, now, metrics.D(now.Sub(sentAt)), tags)
 		c.reportMetric(c.metrics.RequestCount, now, 1, tags)
+		c.reportMetric(c.metrics.FailedRequestCount, now, 0, tags)
 
 		delete(c.hopIds, hopByHopID)
 

--- a/diameter.go
+++ b/diameter.go
@@ -142,17 +142,16 @@ func (c *DiameterClient) Connect(address string) error {
 
 	conn, err := c.client.DialNetwork(c.transportProtocol, address)
 	if err != nil {
-		log.Errorf("Error connecting to %s, %v\n", "localhost:3368", err)
+		log.Errorf("Error connecting to %s, %v\n", address, err)
 		return err
 	}
-	log.Infof("Connected to %s\n", "localhost:3868")
+	log.Infof("Connected to %s\n", address)
 
 	c.conn = conn
 	return nil
 }
 
 func (c *DiameterClient) Send(msg *DiameterMessage) (*DiameterMessage, error) {
-
 	if c.conn == nil {
 		return nil, errors.New("Not connected")
 	}

--- a/diameter.go
+++ b/diameter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/fiorix/go-diameter/v4/diam"
@@ -182,9 +183,12 @@ func (c *DiameterClient) Send(msg *DiameterMessage) (*DiameterMessage, error) {
 	// Wait for Response
 	select {
 	case resp := <-c.hopIds[hopByHopID]:
+		tags := map[string]string{
+			"cmd_code": strconv.FormatUint(uint64(msg.diamMsg.Header.CommandCode), 10),
+		}
 		now := time.Now()
-		c.reportMetric(c.metrics.RequestDuration, time.Now(), metrics.D(now.Sub(sentAt)))
-		c.reportMetric(c.metrics.RequestCount, time.Now(), 1)
+		c.reportMetric(c.metrics.RequestDuration, time.Now(), metrics.D(now.Sub(sentAt)), tags)
+		c.reportMetric(c.metrics.RequestCount, time.Now(), 1, tags)
 
 		delete(c.hopIds, hopByHopID)
 

--- a/example/example.js
+++ b/example/example.js
@@ -46,7 +46,7 @@ export default function () {
     ])))
 
     const cca = client.send(ccr)
-    console.log("CCA: ", cca)
+    console.log(`CCA: ${cca}`)
 
     const resultCode = cca.findAVP(code.ResultCode, 0)
     check(resultCode, {'Result-Code == 2001': r => r == 2001,})

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,10 @@ require (
 	github.com/fiorix/go-diameter/v4 v4.0.5-0.20231116194707-845be291bb4b
 )
 
-require golang.org/x/crypto v0.14.0 // indirect
+require (
+	golang.org/x/crypto v0.14.0 // indirect
+	google.golang.org/genproto v0.0.0-20231127180814-3a041ad873d4 // indirect
+)
 
 require (
 	github.com/dlclark/regexp2 v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto v0.0.0-20200903010400-9bfcb5116336 h1:ZcAny/XH59BbzUOKydQpvIlklwibW3T9SvDE5cGhdzc=
 google.golang.org/genproto v0.0.0-20200903010400-9bfcb5116336/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20231127180814-3a041ad873d4 h1:W12Pwm4urIbRdGhMEg2NM9O3TWKjNcxQhs46V0ypf/k=
+google.golang.org/genproto v0.0.0-20231127180814-3a041ad873d4/go.mod h1:5RBcpGRxr25RbDzY5w+dmaqpSEvl8Gwl1x2CICf60ic=
 google.golang.org/grpc v1.41.0 h1:f+PlOh7QV4iIJkPrx5NQ7qaNGFQ3OTse67yaDHfju4E=
 google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/metrics.go
+++ b/metrics.go
@@ -18,7 +18,7 @@ func registerMetrics(vu modules.VU) DiameterMetrics {
 	metrics := DiameterMetrics{
 		RequestDuration:    registry.MustNewMetric("diameter_req_duration", metrics.Trend, metrics.Time),
 		RequestCount:       registry.MustNewMetric("diameter_req_count", metrics.Counter, metrics.Default),
-		FailedRequestCount: registry.MustNewMetric("diameter_req_failed", metrics.Counter, metrics.Default),
+		FailedRequestCount: registry.MustNewMetric("diameter_req_failed", metrics.Rate, metrics.Default),
 	}
 	return metrics
 }

--- a/metrics.go
+++ b/metrics.go
@@ -21,7 +21,7 @@ func registerMetrics(vu modules.VU) DiameterMetrics {
 	return metrics
 }
 
-func (c *DiameterClient) reportMetric(metric *metrics.Metric, now time.Time, value float64) {
+func (c *DiameterClient) reportMetric(metric *metrics.Metric, now time.Time, value float64, tags map[string]string) {
 	state := c.vu.State()
 	ctx := c.vu.Context()
 	if state == nil || ctx == nil {
@@ -32,6 +32,7 @@ func (c *DiameterClient) reportMetric(metric *metrics.Metric, now time.Time, val
 		Time: now,
 		TimeSeries: metrics.TimeSeries{
 			Metric: metric,
+			Tags:   metrics.NewRegistry().RootTagSet().WithTagsFromMap(tags),
 		},
 		Value: value,
 	})

--- a/metrics.go
+++ b/metrics.go
@@ -8,15 +8,17 @@ import (
 )
 
 type DiameterMetrics struct {
-	RequestDuration *metrics.Metric
-	RequestCount    *metrics.Metric
+	RequestDuration    *metrics.Metric
+	RequestCount       *metrics.Metric
+	FailedRequestCount *metrics.Metric
 }
 
 func registerMetrics(vu modules.VU) DiameterMetrics {
 	registry := vu.InitEnv().Registry
 	metrics := DiameterMetrics{
-		RequestDuration: registry.MustNewMetric("diameter_req_duration", metrics.Trend, metrics.Time),
-		RequestCount:    registry.MustNewMetric("diameter_req_count", metrics.Counter, metrics.Default),
+		RequestDuration:    registry.MustNewMetric("diameter_req_duration", metrics.Trend, metrics.Time),
+		RequestCount:       registry.MustNewMetric("diameter_req_count", metrics.Counter, metrics.Default),
+		FailedRequestCount: registry.MustNewMetric("diameter_req_failed", metrics.Counter, metrics.Default),
 	}
 	return metrics
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,38 @@
+package diameter
+
+import (
+	"time"
+
+	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/metrics"
+)
+
+type DiameterMetrics struct {
+	RequestDuration *metrics.Metric
+	RequestCount    *metrics.Metric
+}
+
+func registerMetrics(vu modules.VU) DiameterMetrics {
+	registry := vu.InitEnv().Registry
+	metrics := DiameterMetrics{
+		RequestDuration: registry.MustNewMetric("diameter_req_duration", metrics.Trend, metrics.Time),
+		RequestCount:    registry.MustNewMetric("diameter_req_count", metrics.Counter, metrics.Default),
+	}
+	return metrics
+}
+
+func (c *DiameterClient) reportMetric(metric *metrics.Metric, now time.Time, value float64) {
+	state := c.vu.State()
+	ctx := c.vu.Context()
+	if state == nil || ctx == nil {
+		return
+	}
+
+	metrics.PushIfNotDone(ctx, state.Samples, metrics.Sample{
+		Time: now,
+		TimeSeries: metrics.TimeSeries{
+			Metric: metric,
+		},
+		Value: value,
+	})
+}

--- a/module.go
+++ b/module.go
@@ -1,23 +1,34 @@
 package diameter
 
 import (
-	"github.com/dop251/goja"
 	"go.k6.io/k6/js/modules"
 )
 
 type (
 	Diameter struct {
 		vu      modules.VU
-		exports *goja.Object
+		metrics DiameterMetrics
 	}
 	RootModule struct{}
-	Module     struct {
-		*Diameter
-	}
 )
 
 func init() {
-	modules.Register("k6/x/diameter", &Diameter{})
+	modules.Register("k6/x/diameter", New())
 	modules.Register("k6/x/diameter/avp", &AVP{})
 	modules.Register("k6/x/diameter/dict", &Dict{})
+}
+
+func New() *RootModule {
+	return &RootModule{}
+}
+
+func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
+	return &Diameter{
+		vu:      vu,
+		metrics: registerMetrics(vu),
+	}
+}
+
+func (d *Diameter) Exports() modules.Exports {
+	return modules.Exports{Default: d}
 }


### PR DESCRIPTION
Hello! 

This is a proposal for the implementation of custom metrics for this extension.  As described in #13, currently there are no custom metrics for the Diameter protocol. It would be valuable to provide metrics regarding request latency and the number of requests handled per second, as those are key results that cannot be properly expressed by the default VU metrics (specially in test scenarios where we issue multiple requests to the server, such as in a SIP authentication flow).

My proposal is to add the following metrics (I've marked the ones that are already implemented by this PR): 

- [X] `diameter_req_count` to track the number of requests handled during the test
- [X] `diameter_req_duration` to track the response time of each individual request
- [X] `diameter_req_failed` to track the rate of failed requests. ~In this case it would be nice to provide an API similar to HTTP's [setResponseCallback](https://k6.io/docs/javascript-api/k6-http/setresponsecallback/) to allow the user to define what is a failure response~

With that said, this implementation requires some refactoring in the way that we export the modules to the JavaScript runtime, and I'm not very familiar with this API. 

I'd like to know what you guys think about the proposal and also the design of the implementation.

## Before

![image](https://github.com/MATRIXXSoftware/xk6-diameter/assets/41878330/0e1018da-7eac-45a2-9388-a4c129dbd9d1)

## After

![image](https://github.com/MATRIXXSoftware/xk6-diameter/assets/41878330/9385e754-fe55-405c-987c-aeb79d453f9e)