### PR TITLE
Update README to use correct log-format flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Alternatively, you may run xk6-diameter packaged in Docker using the following c
 docker run \
   --net=host \
   -v $(pwd)/example:/mnt/example \
-  ghcr.io/matrixxsoftware/xk6-diameter run --logformat=raw /mnt/example/example.js  
+  ghcr.io/matrixxsoftware/xk6-diameter run --log-format=raw /mnt/example/example.js  
 ```
 
 ## Generator


### PR DESCRIPTION
Use correct log-format flag, https://k6.io/docs/using-k6/k6-options/reference/#logformat