### PR TITLE
Prepend identifiers with _ when they begin with digit.

### DIFF
--- a/cmd/dict_generator/main.go
+++ b/cmd/dict_generator/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/fiorix/go-diameter/v4/diam/dict"
 	log "github.com/sirupsen/logrus"
@@ -84,6 +85,9 @@ func PrintAvpCode(w io.Writer, parser *dict.Parser) {
 		fmt.Fprintf(w, "    // %s\n", app.Name)
 		for _, avp := range app.AVP {
 			name := strings.ReplaceAll(avp.Name, "-", "")
+			if len(name) != 0 && unicode.IsDigit(rune(name[0])) {
+			    name = "_" + name
+			}
 			fmt.Fprintf(w, "    %-45s %d,\n", name+":", avp.Code)
 		}
 	}


### PR DESCRIPTION
Using ./bin/dict_generator -output example/diam/const.js -dictionary dict/extra.xml generates a dictionary that contains
```
 // Rx
    5GSRANNASReleaseCause:                        572,
    5GMMCause:                                    573,
    5GSMCause:                                    574,
```
which eventually results with syntax
```
SyntaxError: file:///mnt/example/diam/const.js: Identifier directly after number (637:5)
  635 |     ExtendedAPNAMBRUL:                            2849,
  636 |     // Rx
> 637 |     5GSRANNASReleaseCause:                        572,
      |      ^
  638 |     5GMMCause:                                    573,
  639 |     5GSMCause:                                    574,
  640 |     NGAPCause:                                    575,
        at <internal/k6/compiler/lib/babel.min.js>:7:10099(24)
```
Prepending with _ will solve that problem for any digit.