### PR TITLE
Allow command flags to be used when constructing new message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: make
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: bin/k6

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bin/
+bin/*
+!bin/.gitkeep

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ let client = diam.Client({
 export default function () {
     client.connect("localhost:3868")
 
-    let ccr = diam.newMessage(cmd.CreditControl, app.ChargingControl);
+    let ccr = diam.newRequest(cmd.CreditControl, app.ChargingControl);
     ccr.add(avp.New(code.OriginHost,         0,     0,       data.DiameterIdentity("origin.host")))
     ccr.add(avp.New(code.OriginRealm,        0,     0,       data.DiameterIdentity("origin.realm")))
     ccr.add(avp.New(code.DestinationHost,    0,     0,       data.DiameterIdentity("dest.host")))

--- a/cmd/dict_generator/main.go
+++ b/cmd/dict_generator/main.go
@@ -42,6 +42,7 @@ func main() {
 	defer w.Close()
 
 	PrintCmd(w)
+	PrintCmdFlags(w)
 	PrintAppId(w)
 	PrintFlags(w)
 	PrintAvpCode(w, parser)
@@ -66,6 +67,16 @@ func PrintCmd(w io.Writer) {
 	fmt.Fprintf(w, "    %-20s %d,\n", "ReAuth:", 258)
 	fmt.Fprintf(w, "    %-20s %d,\n", "SessionTermination:", 275)
 	fmt.Fprintf(w, "    %-20s %d,\n", "SpendingLimit:", 8388635)
+	fmt.Fprintf(w, "}\n")
+	fmt.Fprintf(w, "\n")
+}
+
+func PrintCmdFlags(w io.Writer) {
+	fmt.Fprintf(w, "export const cmdFlag = {\n")
+	fmt.Fprintf(w, "    %-20s 0x%x, // request bit\n", "Request:", 1 << 7)
+	fmt.Fprintf(w, "    %-20s 0x%x, // proxiable bit\n", "Proxiable:", 1 << 6)
+	fmt.Fprintf(w, "    %-20s 0x%x, // error bit\n", "Error:", 1 << 5)
+	fmt.Fprintf(w, "    %-20s 0x%x, // re-transmitted bit\n", "Retransmit:", 1 << 4)
 	fmt.Fprintf(w, "}\n")
 	fmt.Fprintf(w, "\n")
 }

--- a/diameter.go
+++ b/diameter.go
@@ -213,9 +213,15 @@ func (c *DiameterClient) Send(msg *DiameterMessage) (*DiameterMessage, error) {
 	}
 }
 
-func (*Diameter) NewMessage(cmd uint32, appid uint32) *DiameterMessage {
+func (*Diameter) NewRequest(cmd uint32, appid uint32) *DiameterMessage {
 	return &DiameterMessage{
 		diamMsg: diam.NewRequest(cmd, appid, dict.Default),
+	}
+}
+
+func (*Diameter) NewMessage(cmd uint32, appid uint32, flags uint8) *DiameterMessage {
+	return &DiameterMessage{
+		diamMsg: diam.NewMessage(cmd, flags, appid, 0, 0, dict.Default),
 	}
 }
 

--- a/example/diam/const.js
+++ b/example/diam/const.js
@@ -3,6 +3,13 @@ export const cmd = {
     CreditControl:       272,
 }
 
+export const cmdFlag = {
+    Request:             0x80, // request bit
+    Proxiable:           0x40, // proxiable bit
+    Error:               0x20, // error bit
+    Retransmit:          0x10, // re-transmitted bit
+}
+
 export const app = {
     Accounting:          3,
     ChargingControl:     4,

--- a/example/example.js
+++ b/example/example.js
@@ -1,7 +1,7 @@
 import diam from 'k6/x/diameter'
 import avp from 'k6/x/diameter/avp'
 import dict from 'k6/x/diameter/dict'
-import { cmd, app, code, flag, vendor } from './diam/const.js'
+import { cmd, cmdFlag, app, code, flag, vendor } from './diam/const.js'
 import { check } from 'k6'
 
 export let options = {
@@ -32,7 +32,7 @@ let client = diam.Client({
 export default function () {
     client.connect("localhost:3868")
 
-    let ccr = diam.newMessage(cmd.CreditControl, app.ChargingControl);
+    let ccr = diam.newMessage(cmd.CreditControl, app.ChargingControl, cmdFlag.Request);
     ccr.add(avp.New(code.OriginHost,         0,     0,       data.DiameterIdentity("origin.host")))
     ccr.add(avp.New(code.OriginRealm,        0,     0,       data.DiameterIdentity("origin.realm")))
     ccr.add(avp.New(code.DestinationHost,    0,     0,       data.DiameterIdentity("dest.host")))


### PR DESCRIPTION
`NewMessage()` now accept command flags.

e.g. to create a proxiable request
```javascript
import { cmd, cmdFlag, app } from './diam/const.js';

diam.newMessage(cmd.CreditControl, app.ChargingControl, cmdFlag.Request | cmdFlag.Proxiable);
```

Introduce `NewRequest()` for message to have the R-bit pre-configured.

e.g. to create a request
```javascript
import { cmd, app } from './diam/const.js';

diam.newRequest(cmd.CreditControl, app.ChargingControl);
```

Fixes #22.